### PR TITLE
Adds support for asynchronously queued jobs in tests

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Support\Facades;
 
+use Closure;
 use Illuminate\Queue\Worker;
+use Illuminate\Support\Testing\Fakes\AsyncQueueFake;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 
 /**
@@ -50,6 +52,21 @@ class Queue extends Facade
         static::swap($fake = new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()));
 
         return $fake;
+    }
+
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @param  array|string  $jobsToFake
+     * @return \Illuminate\Support\Testing\Fakes\AsyncQueueFake
+     */
+    public static function async(Closure $callback, $jobsToRunAsynchronously = [])
+    {
+        static::swap($fake = new AsyncQueueFake(static::getFacadeApplication(), $jobsToRunAsynchronously, static::getFacadeRoot()));
+
+        $callback();
+
+        return $fake->dispatch();
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+
+class AsyncQueueFake extends QueueFake
+{
+    /**
+     * Process all of the jobs on the queue using a fresh application instance.
+     *
+     * @return self
+     */
+    public function dispatch()
+    {
+        foreach ($this->jobs as $job => $instances) {
+            foreach ($instances as $instance) {
+                $this->refreshApplication();
+
+                [$job, $data, $queue] = array_values($instance);
+
+                is_object($job) && isset($job->connection)
+                    ? $this->queue->connection($job->connection)->push($job, $data, $queue)
+                    : $this->queue->push($job, $data, $queue);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Refresh the application.
+     *
+     * @return \Illuminate\Foundation\Application
+     *
+     * @throws RuntimeException
+     */
+    protected function refreshApplication()
+    {
+        if (file_exists(getcwd().'/bootstrap/app.php')) {
+            $db = app('db');
+            $queue = app('queue');
+
+            $app = require getcwd().'/bootstrap/app.php'
+            $app->make(Kernel::class)->bootstrap();
+
+            Queue::swap($queue);
+            DB::swap($db);
+            Model::setConnectionResolver($db);
+
+            return $app;
+        }
+
+        throw new RuntimeException('Unable to resolve application.');
+    }
+}

--- a/tests/Support/SupportTestingAsyncQueueFakeTest.php
+++ b/tests/Support/SupportTestingAsyncQueueFakeTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Testing\Fakes\AsyncQueueFake;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class SupportTestingAsyncQueueFakeTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Support\Testing\Fakes\AsyncQueueFake
+     */
+    private $fake;
+
+    /**
+     * @var \Illuminate\Tests\Support\JobStub
+     */
+    private $job;
+
+    /**
+     * @var int
+     */
+    private $applicationRefreshes = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+
+        $this->post = Post::create(['title' => 'xyz', 'slug' => 'xyz']);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testModelRehydrated()
+    {
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager();
+
+        $queue->push($job);
+        $queue->dispatch();
+
+        $queue->assertPushed(JobStub::class);
+    }
+
+    public function testDeletedModelIsNotRehydrated()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager();
+
+        $queue->push($job);
+        $this->post->delete();
+        $queue->dispatch();
+    }
+
+    public function testJobsAreAllDispatchedInANewProcess()
+    {
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager();
+
+        $queue->push($job);
+        $queue->push($job);
+        $queue->dispatch();
+
+        $queue->assertPushed(JobStub::class, 2);
+        $this->assertSame(2, $this->applicationRefreshes);
+    }
+
+    public function testOnlySpecifiedJobsAreRunAsynchronously()
+    {
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager([JobStub::class]);
+
+        $queue->push($job);
+        $queue->push($job);
+        $queue->push(new SecondJobStub);
+        $queue->dispatch();
+
+        $queue->assertPushed(JobStub::class, 2);
+        $this->assertSame(2, $this->applicationRefreshes);
+    }
+
+    protected function refreshQueueApplication()
+    {
+        $db = $this->app->make('db');
+        $queue = $this->app->make('queue');
+
+        $app = parent::refreshApplication();
+
+        Queue::swap($queue);
+        DB::swap($db);
+        Model::setConnectionResolver($db);
+
+        $this->applicationRefreshes++;
+
+        return $app;
+    }
+
+    protected function mockQueueManager($jobsToRunAsynchronously = [], $app = null, $queue = null)
+    {
+        $queueManager = m::mock(
+            AsyncQueueFake::class, [
+                $app ?: $this->app,
+                $jobsToRunAsynchronously,
+                $queue ?: $this->app->make('queue'),
+            ])
+        ->makePartial();
+        $queueManager->shouldAllowMockingProtectedMethods();
+        $queueManager->shouldReceive('refreshApplication')
+            ->andReturnUsing(fn () => $this->refreshQueueApplication());
+
+        return $queueManager;
+    }
+}
+
+class JobStub implements ShouldQueue
+{
+    use SerializesModels;
+
+    public $post;
+
+    public function __construct(Post $post)
+    {
+        $this->post = $post;
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+class SecondJobStub implements ShouldQueue
+{
+    public function handle()
+    {
+        //
+    }
+}
+
+class Post extends Model
+{
+    protected $guarded = [];
+
+    public $table = 'posts';
+}


### PR DESCRIPTION
### Questions / Thoughts

- Do you think this solves a problem?
- I added this to the `Queue` facade as I think it's in a similar vein to to `Queue::fake()`. However, it's not actually faking anything - instead, it catches all the jobs fired in the callback and processes them using a clean application instance. This  could result in it being used in an application if the functionality is not understood. I guess the same applies for `fake`, but it seems more obvious that should only apply to tests.
- To make this work, I have to create a new application instance. The only other place I could find this being used was in [ParallelRunner](https://github.com/joedixon/framework/blob/9.x/src/Illuminate/Testing/ParallelRunner.php#L152-L175). Do you think it's ok not to reuse this code?
- Perhaps if I moved this to a test helper, my concerns around usage in application land would be moot?
- I have written tests for this, but I'm not sure I have put them in the right place so would be grateful for input on that.

### Description

This PR adds support for asynchronously queued jobs in tests.

Imagine a scenario where you have a feature test for an endpoint and that endpoint fires off a job called "PurgeNetworkResources"

That job should receive a "Network" model which you pass in from your controller, but without thinking, you delete it later in the request.

Now, when you run the test, the job runs synchronously and you get a nice green tick. However out in the wild, the job is queued and you get a "Model not found" bug report in your error tracker as it no longer exists when the job handler attempts to refetch it.

This is just one example, but a few times, I have run into scenarios that have bitten me as I've not been able to execute that job in isolation as part of my test.

Of course, some of these issues are taken away if you unit test the job (though this doesn't guard against the deleted model example), but sometimes I just want to test my feature end to end and know it's behaving as it will do in production.